### PR TITLE
Add create editor link endpoint

### DIFF
--- a/lib/swiftner/API/video_content.rb
+++ b/lib/swiftner/API/video_content.rb
@@ -44,6 +44,17 @@ module Swiftner
         )
         self
       end
+
+      # Created a url to the embedded editor
+      # @return [String] url to editor
+      def create_editor_link
+        result = client.post(
+          "/video-content/create_editor_link/#{id}",
+          body: {}.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+        result["url"]
+      end
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -26,6 +26,7 @@ def stub_api_requests(api_key)
   stub_get("https://api.swiftner.com/video-content/get-all/", [{ id: 1, media_type: "video" }].to_json, api_key)
   stub_get("https://api.swiftner.com/video-content/get/1", { id: 1, media_type: "video" }.to_json, api_key)
   stub_put("https://api.swiftner.com/video-content/update/1", api_key)
+  stub_post_body("https://api.swiftner.com/video-content/create_editor_link/1", { url: "https://app.swiftner.com/editor/1/abcde-12345" }.to_json, api_key)
 
   stub_get("https://api.swiftner.com/linked-content/get-all/", [{ id: 1, type: "linked_content", url: "https://youtube.com" }].to_json, api_key)
   stub_get("https://api.swiftner.com/linked-content/get/1", { id: 1, type: "linked_content", url: "https://youtube.com" }.to_json, api_key)

--- a/test/video_content_test.rb
+++ b/test/video_content_test.rb
@@ -26,4 +26,10 @@ class VideoContentTest < Minitest::Test
     assert_equal "New title", video_content.details["title"]
     assert_equal 1, video_content.id
   end
+
+  def test_create_editor_link
+    video_content = @video_content_service.find(1)
+    response = video_content.create_editor_link
+    assert response.is_a?(String)
+  end
 end


### PR DESCRIPTION
## What this PR is adding
New endpoint: `/video-content/create_editor_link/{video_content_id}`
Method: `Swiftner::API::VideoContent#create_editor_link`
Return format: `https://app.swiftner.com/editor/1/{editor_hash}`